### PR TITLE
For systems that are not 'posix' (Windows 8.1) use getenv() to seed the ...

### DIFF
--- a/maven.py
+++ b/maven.py
@@ -86,6 +86,8 @@ class AsyncMavenProcess(object):
         # add /usr/local/bin to the path (for some reason not present through sublime)
         if os.name == 'posix':
             env['PATH'] = os.environ['PATH'] + os.pathsep + '/usr/local/bin'
+        else:
+            env['PATH'] = os.getenv('PATH')
 
         m2_home = None
         if 'M2_HOME' in env:


### PR DESCRIPTION
When trying to use this module on Windows, the path was not getting set properly.
This PR fixes that.
